### PR TITLE
Fixed linter config error

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,7 +31,6 @@ jobs:
         uses: super-linter/super-linter/slim@v8.2.0
         env:
           FILTER_REGEX_EXCLUDE: '.*(node_modules/).*'
-          VALIDATE_MARKDOWN: false
           VALIDATE_YAML: true
           VALIDATE_XML: true
           VALIDATE_GITLEAKS: true


### PR DESCRIPTION
To fix `Behavior not supported, please either only include (VALIDATE=true) or exclude (VALIDATE=false) linters, but not both`