### PR TITLE
93 day of the week misalignment with spending data

### DIFF
--- a/apps/frontend/src/app/(protected)/budget/page.tsx
+++ b/apps/frontend/src/app/(protected)/budget/page.tsx
@@ -33,6 +33,13 @@ export default function BudgetPage() {
     color: "#4ECDC4",
   });
 
+  const parseDateInput = (value: string) => {
+    const [year, month, day] = value.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    date.setHours(12, 0, 0, 0);
+    return date;
+  };
+
   useEffect(() => {
     loadDashboard();
   }, []);
@@ -135,7 +142,7 @@ export default function BudgetPage() {
         amountCents: Math.round(parseFloat(formData.amount) * 100),
         currency: formData.currency as Currency,
         period: formData.period,
-        startDate: new Date(formData.startDate),
+        startDate: parseDateInput(formData.startDate),
         alertThreshold: parseInt(formData.alertThreshold),
       };
       await budgetService.createBudget(budgetData);

--- a/apps/frontend/src/app/(protected)/home/page.tsx
+++ b/apps/frontend/src/app/(protected)/home/page.tsx
@@ -218,6 +218,8 @@ const CalendarCard: React.FC<{ transactions: TransactionDTO[] }> = ({ transactio
   );
 };
 
+const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 export default function HomePage() {
   const router = useRouter();
   const [dashboard, setDashboard] = useState<BudgetDashboard | null>(null);

--- a/apps/frontend/src/app/(protected)/transactions/page.tsx
+++ b/apps/frontend/src/app/(protected)/transactions/page.tsx
@@ -54,6 +54,13 @@ export default function TransactionsPage() {
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
 
+  const parseDateInput = (value: string) => {
+    const [year, month, day] = value.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    date.setHours(12, 0, 0, 0);
+    return date;
+  };
+
   // ===== Pagination =====
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -109,7 +116,7 @@ export default function TransactionsPage() {
         categoryId: selectedCategoryId || undefined,
         amountCents: cents,
         note: note || description || undefined,
-        occurredAt: new Date(date),
+        occurredAt: parseDateInput(date),
       });
 
       const newTx = result.transaction;
@@ -192,7 +199,7 @@ export default function TransactionsPage() {
         amountCents: cents,
         categoryId: editCategoryId,
         note: editNote,
-        occurredAt: new Date(editDate),
+        occurredAt: parseDateInput(editDate),
       });
       await loadTransactions();
       setShowEditModal(false);
@@ -313,8 +320,8 @@ export default function TransactionsPage() {
     else if (dateRange === "90") withinRange = txDate >= now - 90 * 24 * 60 * 60 * 1000;
     else if (dateRange === "custom" && customStart && customEnd) {
       withinRange =
-        txDate >= new Date(customStart).getTime() &&
-        txDate <= new Date(customEnd).getTime();
+        txDate >= parseDateInput(customStart).getTime() &&
+        txDate <= parseDateInput(customEnd).getTime();
     }
 
     return matchesCategory && matchesSearch && withinRange;


### PR DESCRIPTION
**The Problem:**
- Date input strings (e.g., "2025-01-15") were converted to Date objects at UTC midnight (00:00:00Z)
- Users in negative UTC timezones (like us in Winnipeg, UTC-5)  would dates displayed as the previous day
    - Example: Entering Jan 15 would display as Jan 14 in UTC-5 timezone
**The Solution:**
- Created parseDateInput() helper function in transaction and budget pages
- Parses date strings manually using split("-") to extract year, month, and day components
- Creates Date object using new Date(year, month - 1, day) which respects local timezone
- Sets time to local noon (12:00) to avoid edge cases near midnight boundaries (still no need for specific time tracking since transactions are tracked by date only with regards to the user)
These changes ensure dates remain consistent regardless of user's timezone offset.
**Files Modified:**
apps/frontend/src/app/(protected)/transactions/page.tsx - Added helper, updated add/edit transaction date handling
apps/frontend/src/app/(protected)/budget/page.tsx - Added helper, updated budget creation date handling